### PR TITLE
Completed dot pathed object tranformation

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,3 +238,26 @@ function foreach(object, block, context) {
 	}
 }
 exports.foreach = foreach;
+
+function dotpath(data, dotkeys, preserve) {
+	if(!preserve) preserve = false;
+	var create = !preserve;
+	if(create)
+		if(!data) data = {};
+	var value;
+	for(var key in dotkeys) {
+		value = data;
+		var keys = key.split('.');
+		var k = keys.pop();
+		while(keys.length) {
+			var next = keys.shift();
+			if(create)
+				value = value[next] = value[next] || {};
+			else
+				return undefined;
+		}
+		value[k] = dotkeys[key]
+	}
+	return data;
+}
+exports.dotpath = dotpath;


### PR DESCRIPTION
Here's an implementation of the unfinished/buggy object transformation which should do what was desired.

Running in the console with the example returns the desired output below:

```
{
    "foo":{
        "bar":"bluebar",
        "color":"blue"
    }
} 
```

I also formatted the code to be more readable, I hope you don't mind. The only code which was actually changed is the `dotpath()` function
